### PR TITLE
API に関連する型定義を 1 ファイルに集約

### DIFF
--- a/src/features/home/components/ChartContainer/ChartContainer.tsx
+++ b/src/features/home/components/ChartContainer/ChartContainer.tsx
@@ -7,7 +7,7 @@ import { ChartPresenter } from "~/features/home/components/ChartPresenter";
 import { PopulationLabels } from "~/features/home/components/PopulationLabels";
 import { useSelectedPrefCodesContext } from "~/features/home/contexts/SelectedPrefCodesContext";
 import { usePopulationData } from "~/features/home/hooks/usePopulationData";
-import { PopulationType } from "~/features/home/types/api";
+import { PopulationType } from "~/types/api";
 
 export function ChartContainer() {
   const { codes } = useSelectedPrefCodesContext();

--- a/src/features/home/components/PopulationLabels/PopulationLabels.tsx
+++ b/src/features/home/components/PopulationLabels/PopulationLabels.tsx
@@ -9,7 +9,7 @@ import {
   populationLabelValues,
   populationValueToLabel,
 } from "~/features/home/lib/const";
-import { PopulationType } from "~/features/home/types/api";
+import { PopulationType } from "~/types/api";
 
 type Props = {
   type: PopulationType;

--- a/src/features/home/hooks/usePopulationData.ts
+++ b/src/features/home/hooks/usePopulationData.ts
@@ -1,12 +1,9 @@
 import { useEffect, useState } from "react";
 
 import { getPopulationData } from "~/features/home/lib/getPopulationData";
-import {
-  PopulationType,
-  RawPopulationResponses,
-} from "~/features/home/types/api";
 import { RechartsDataItem } from "~/features/home/types/recharts";
 import { requestPopulation } from "~/lib/requestPopulation";
+import { PopulationType, RawPopulationResponses } from "~/types/api";
 
 export function usePopulationData(codes: number[], type: PopulationType) {
   const [data, setData] = useState<RechartsDataItem[]>([]);

--- a/src/features/home/lib/const.ts
+++ b/src/features/home/lib/const.ts
@@ -1,4 +1,4 @@
-import { PopulationType } from "~/features/home/types/api";
+import { PopulationType } from "~/types/api";
 
 export const populationValueToLabel: { [key: number]: string } = {
   0: "総人口",

--- a/src/features/home/lib/getPopulationData.ts
+++ b/src/features/home/lib/getPopulationData.ts
@@ -1,9 +1,6 @@
 import { populationValueToLabel } from "~/features/home/lib/const";
-import {
-  RawPopulationResponses,
-  PopulationType,
-} from "~/features/home/types/api";
 import { RechartsDataItem } from "~/features/home/types/recharts";
+import { RawPopulationResponses, PopulationType } from "~/types/api";
 
 export function getPopulationData(
   rawData: RawPopulationResponses,

--- a/src/features/home/types/api.ts
+++ b/src/features/home/types/api.ts
@@ -1,7 +1,0 @@
-import { PopulationResponse } from "~/types/api";
-
-export type RawPopulationResponses = {
-  [n: number]: PopulationResponse["result"]["data"];
-};
-
-export type PopulationType = 0 | 1 | 2 | 3;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,3 +20,9 @@ export type PopulationResponse = {
     data: PopulationData[];
   };
 };
+
+export type RawPopulationResponses = {
+  [n: number]: PopulationResponse["result"]["data"];
+};
+
+export type PopulationType = 0 | 1 | 2 | 3;


### PR DESCRIPTION
## Issue

なし

## 補足

`features` 配下の types と `src` 配下の types に別れていたが、分割の基準が曖昧なので 1 ファイルに集約する