### PR TITLE
npm scripts から postbuild を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ MSW 利用時は Cookie `error` に以下の値を格納することでブラウ
 | 429   | 429         | "{"message":null}"                                                                                                            |
 | 500   | 500         | "Server Error"                                                                                                                |
 
+`next start` で起動する場合は、`next build` 後に以下の URL にアクセスする。
+
+<http://local.yumemi-fe-test.com:3000/>
+
 ## デプロイ
 
 `main` ブランチへのマージをトリガーに GitHub Actions から Vercel へデプロイする。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dev": "next dev --experimental-https --experimental-https-key ./cert/key.pem --experimental-https-cert ./cert/cert.pem",
     "dev:mock": "NEXT_PUBLIC_API_MOCKING=enabled pnpm dev",
     "build": "next build",
-    "postbuild": "rm -rf ./out/mockServiceWorker.js",
     "start": "next start",
     "lint": "pnpm lint:typecheck && pnpm lint:eslint && pnpm lint:prettier && pnpm lint:stylelint",
     "lint:eslint": "next lint",


### PR DESCRIPTION
## Issue

なし

## 補足

- SSG しない場合は postbuild の処理が不要なため削除
- `next start` で起動する場合は SSL 接続できないため README に追記